### PR TITLE
[0.4.0] Remove JSON stringify

### DIFF
--- a/EdgeConfigDataAdapter.ts
+++ b/EdgeConfigDataAdapter.ts
@@ -43,10 +43,15 @@ export class EdgeConfigDataAdapter implements IDataAdapter {
     }
 
     const data = await this.edgeConfigClient.get(this.edgeConfigItemKey);
-    if (data === undefined) {
+    if (data == null) {
       return { error: new Error(`key (${key}) does not exist`) };
     }
-    return { result: JSON.stringify(data) };
+    if (typeof data !== "object") {
+      return {
+        error: new Error(`Edge Config value expected to be an object or array`),
+      };
+    }
+    return { result: data };
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsig-node-vercel",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "statsig-node": "5.1.0"
+    "statsig-node": "5.22.0"
   },
   "peerDependencies": {
     "@vercel/edge-config": "^0.1.4"
@@ -22,6 +22,7 @@
     "@babel/preset-env": "^7.18.10",
     "@babel/preset-typescript": "^7.18.6",
     "@types/jest": "^28.1.8",
+    "@types/node": "^20.14.10",
     "@vercel/edge-config": "^0.2.1",
     "jest": "^29.0.0",
     "jest-fetch-mock": "^3.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,25 +1,27 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@babel/core': ^7.18.13
   '@babel/preset-env': ^7.18.10
   '@babel/preset-typescript': ^7.18.6
   '@types/jest': ^28.1.8
+  '@types/node': ^20.14.10
   '@vercel/edge-config': ^0.2.1
   jest: ^29.0.0
   jest-fetch-mock: ^3.0.3
-  statsig-node: 5.1.0
+  statsig-node: 5.22.0
 
 dependencies:
-  statsig-node: 5.1.0
+  statsig-node: 5.22.0
 
 devDependencies:
   '@babel/core': 7.18.13
   '@babel/preset-env': 7.18.10_@babel+core@7.18.13
   '@babel/preset-typescript': 7.18.6_@babel+core@7.18.13
   '@types/jest': 28.1.8
+  '@types/node': 20.14.10
   '@vercel/edge-config': 0.2.1
-  jest: 29.0.0
+  jest: 29.0.0_@types+node@20.14.10
   jest-fetch-mock: 3.0.3
 
 packages:
@@ -1262,7 +1264,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.0.0
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       chalk: 4.1.2
       jest-message-util: 29.0.0
       jest-util: 29.0.0
@@ -1283,14 +1285,14 @@ packages:
       '@jest/test-result': 29.0.0
       '@jest/transform': 29.0.0
       '@jest/types': 29.0.0
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.3.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.0.0
-      jest-config: 29.0.0_@types+node@18.7.13
+      jest-config: 29.0.0_@types+node@20.14.10
       jest-haste-map: 29.0.0
       jest-message-util: 29.0.0
       jest-regex-util: 29.0.0
@@ -1317,7 +1319,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.0.0
       '@jest/types': 29.0.0
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       jest-mock: 29.0.0
     dev: true
 
@@ -1351,7 +1353,7 @@ packages:
     dependencies:
       '@jest/types': 29.0.0
       '@sinonjs/fake-timers': 9.1.2
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       jest-message-util: 29.0.0
       jest-mock: 29.0.0
       jest-util: 29.0.0
@@ -1384,7 +1386,7 @@ packages:
       '@jest/transform': 29.0.0
       '@jest/types': 29.0.0
       '@jridgewell/trace-mapping': 0.3.15
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -1480,7 +1482,7 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       '@types/yargs': 17.0.11
       chalk: 4.1.2
     dev: true
@@ -1492,7 +1494,7 @@ packages:
       '@jest/schemas': 29.0.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       '@types/yargs': 17.0.11
       chalk: 4.1.2
     dev: true
@@ -1583,7 +1585,7 @@ packages:
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
     dev: true
 
   /@types/istanbul-lib-coverage/2.0.4:
@@ -1609,15 +1611,11 @@ packages:
       pretty-format: 28.1.3
     dev: true
 
-  /@types/node-fetch/2.6.2:
-    resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
+  /@types/node/20.14.10:
+    resolution: {integrity: sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==}
     dependencies:
-      '@types/node': 18.7.13
-      form-data: 3.0.1
-    dev: false
-
-  /@types/node/18.7.13:
-    resolution: {integrity: sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==}
+      undici-types: 5.26.5
+    dev: true
 
   /@types/prettier/2.7.0:
     resolution: {integrity: sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==}
@@ -1692,10 +1690,6 @@ packages:
     dependencies:
       sprintf-js: 1.0.3
     dev: true
-
-  /asynckit/0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: false
 
   /babel-jest/29.0.0_@babel+core@7.18.13:
     resolution: {integrity: sha512-EJM2dqxz9+uWJLLucZLPYAmRsHHt1IMkitAHGqjDlIP2IQXzkIMO3ATbBWk0lU6VwX4rNeVN04t/DDB8U5C2rg==}
@@ -1944,13 +1938,6 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
-  /combined-stream/1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      delayed-stream: 1.0.0
-    dev: false
-
   /concat-map/0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
@@ -2013,11 +2000,6 @@ packages:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
     dev: true
-
-  /delayed-stream/1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-    dev: false
 
   /detect-newline/3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -2145,15 +2127,6 @@ packages:
       locate-path: 5.0.0
       path-exists: 4.0.0
     dev: true
-
-  /form-data/3.0.1:
-    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
-    engines: {node: '>= 6'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-    dev: false
 
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -2381,7 +2354,7 @@ packages:
       '@jest/expect': 29.0.0
       '@jest/test-result': 29.0.0
       '@jest/types': 29.0.0
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -2400,7 +2373,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/29.0.0:
+  /jest-cli/29.0.0_@types+node@20.14.10:
     resolution: {integrity: sha512-VZUPQjWJKL8QABFiBk1tHeJ3czBodjU9r22ceQmeL7X8/M73FYxTte0RkYPHI2SiLPWy99GZNWA+oOu9x0xKOA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -2417,7 +2390,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 29.0.0
+      jest-config: 29.0.0_@types+node@20.14.10
       jest-util: 29.0.0
       jest-validate: 29.0.0
       prompts: 2.4.2
@@ -2428,7 +2401,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config/29.0.0:
+  /jest-config/29.0.0_@types+node@20.14.10:
     resolution: {integrity: sha512-RbcUgQBJDS0O8OThWUwm5UCfzo0zOymUX/cJzUNlYB1ZWqe3M8MFEcgwqgZSifYuYTi46xWu5cmkMiyRQAdnMw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -2443,45 +2416,7 @@ packages:
       '@babel/core': 7.18.13
       '@jest/test-sequencer': 29.0.0
       '@jest/types': 29.0.0
-      babel-jest: 29.0.0_@babel+core@7.18.13
-      chalk: 4.1.2
-      ci-info: 3.3.2
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-circus: 29.0.0
-      jest-environment-node: 29.0.0
-      jest-get-type: 29.0.0
-      jest-regex-util: 29.0.0
-      jest-resolve: 29.0.0
-      jest-runner: 29.0.0
-      jest-util: 29.0.0
-      jest-validate: 29.0.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.0.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /jest-config/29.0.0_@types+node@18.7.13:
-    resolution: {integrity: sha512-RbcUgQBJDS0O8OThWUwm5UCfzo0zOymUX/cJzUNlYB1ZWqe3M8MFEcgwqgZSifYuYTi46xWu5cmkMiyRQAdnMw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.18.13
-      '@jest/test-sequencer': 29.0.0
-      '@jest/types': 29.0.0
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       babel-jest: 29.0.0_@babel+core@7.18.13
       chalk: 4.1.2
       ci-info: 3.3.2
@@ -2550,7 +2485,7 @@ packages:
       '@jest/environment': 29.0.0
       '@jest/fake-timers': 29.0.0
       '@jest/types': 29.0.0
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       jest-mock: 29.0.0
       jest-util: 29.0.0
     dev: true
@@ -2580,7 +2515,7 @@ packages:
     dependencies:
       '@jest/types': 29.0.0
       '@types/graceful-fs': 4.1.5
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
@@ -2656,7 +2591,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.0.0
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
     dev: true
 
   /jest-pnp-resolver/1.2.2_jest-resolve@29.0.0:
@@ -2710,7 +2645,7 @@ packages:
       '@jest/test-result': 29.0.0
       '@jest/transform': 29.0.0
       '@jest/types': 29.0.0
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       chalk: 4.1.2
       emittery: 0.10.2
       graceful-fs: 4.2.10
@@ -2741,7 +2676,7 @@ packages:
       '@jest/test-result': 29.0.0
       '@jest/transform': 29.0.0
       '@jest/types': 29.0.0
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -2797,7 +2732,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       chalk: 4.1.2
       ci-info: 3.3.2
       graceful-fs: 4.2.10
@@ -2809,7 +2744,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.0.0
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       chalk: 4.1.2
       ci-info: 3.3.2
       graceful-fs: 4.2.10
@@ -2834,7 +2769,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.0.0
       '@jest/types': 29.0.0
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -2846,12 +2781,12 @@ packages:
     resolution: {integrity: sha512-2t9Panx3F9N1wAvRuZT7xLEptRFc1C5G90DOHniIGz1JIgF9uhd5u8jNBsc7wN63lhnaiLeVLnNx21wT7OVFEQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 18.7.13
+      '@types/node': 20.14.10
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest/29.0.0:
+  /jest/29.0.0_@types+node@20.14.10:
     resolution: {integrity: sha512-9uz4Tclskb8WrfRXqu66FsFCFoyYctwWXpruKwnD95FZqkyoEAA1oGH53HUn7nQx7uEgZTKdNl/Yo6DqqU+XMg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -2864,7 +2799,7 @@ packages:
       '@jest/core': 29.0.0
       '@jest/types': 29.0.0
       import-local: 3.1.0
-      jest-cli: 29.0.0
+      jest-cli: 29.0.0_@types+node@20.14.10
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -2961,18 +2896,6 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /mime-db/1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-    dev: false
-
-  /mime-types/2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-    dependencies:
-      mime-db: 1.52.0
-    dev: false
-
   /mimic-fn/2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -3002,10 +2925,18 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: true
 
-  /node-forge/1.3.1:
-    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
-    engines: {node: '>= 6.13.0'}
+  /node-fetch/2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
     dev: false
 
   /node-int64/0.4.0:
@@ -3312,13 +3243,11 @@ packages:
       escape-string-regexp: 2.0.0
     dev: true
 
-  /statsig-node/5.1.0:
-    resolution: {integrity: sha512-pDMdeuYP71R90L/tuRalvcmhKHd0wEnZmnO/PgJDd9UFwBflKxqOMlbxPDyATNcgFFa9YW6IdqJExgdRf0zV7g==}
+  /statsig-node/5.22.0:
+    resolution: {integrity: sha512-g3ULqEbC6o5pu4FhOg1IjJp8IDGA7IUeMbaX+v2DUyk0cja7jH13TPznuHgJxy4ICyOlTBMV1JLagMGNtQdXSg==}
     dependencies:
-      '@types/node-fetch': 2.6.2
       ip3country: 5.0.0
-      node-fetch: 2.6.7
-      node-forge: 1.3.1
+      node-fetch: 2.7.0
       ua-parser-js: 1.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -3447,6 +3376,10 @@ packages:
   /ua-parser-js/1.0.2:
     resolution: {integrity: sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==}
     dev: false
+
+  /undici-types/5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
 
   /unicode-canonical-property-names-ecmascript/2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}


### PR DESCRIPTION
Updated Statsig Node SDK in [5.22.0](https://github.com/statsig-io/node-js-server-sdk/releases/tag/5.22.0) to allow directly parsing object value from the data adapter without JSON.parse.

Now updating the Vercel adapter to pass the EdgeConfig value directly without JSON.stringify
Works for Config specs, ID list lookup, and ID lists