### PR TITLE
[feat] expose option to control if DataAdapter polls for updates from Edge Config

### DIFF
--- a/EdgeConfigDataAdapter.ts
+++ b/EdgeConfigDataAdapter.ts
@@ -10,7 +10,8 @@ export class EdgeConfigDataAdapter implements IDataAdapter {
    * A fully configured Edge Config client
    */
   private edgeConfigClient: EdgeConfigClient;
-  private supportConfigSpecPolling: boolean = false;
+  private edgeConfigIsHydrated: boolean = false;
+  private useEdgeConfigForPollingForUpdates: boolean;
 
   public constructor(options: {
     /**
@@ -29,9 +30,14 @@ export class EdgeConfigDataAdapter implements IDataAdapter {
      * ```
      */
     edgeConfigClient: EdgeConfigClient;
+    /**
+     * Whether to opt out of polling updates from Edge Config.
+     */
+    useEdgeConfigForPollingForUpdates?: boolean;
   }) {
     this.edgeConfigItemKey = options.edgeConfigItemKey;
     this.edgeConfigClient = options.edgeConfigClient;
+    this.useEdgeConfigForPollingForUpdates = options.useEdgeConfigForPollingForUpdates ?? true;
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -51,6 +57,7 @@ export class EdgeConfigDataAdapter implements IDataAdapter {
         error: new Error(`Edge Config value expected to be an object or array`),
       };
     }
+    this.edgeConfigIsHydrated = true;
     return { result: data };
   }
 
@@ -67,7 +74,7 @@ export class EdgeConfigDataAdapter implements IDataAdapter {
     const data = await this.edgeConfigClient.get(this.edgeConfigItemKey);
 
     if (data) {
-      this.supportConfigSpecPolling = true;
+      this.edgeConfigIsHydrated = true;
     }
   }
 
@@ -75,8 +82,8 @@ export class EdgeConfigDataAdapter implements IDataAdapter {
   public async shutdown(): Promise<void> {}
 
   public supportsPollingUpdatesFor(key: string): boolean {
-    if (this.isConfgSpecKey(key)) {
-      return this.supportConfigSpecPolling;
+    if (this.isConfgSpecKey(key) && this.useEdgeConfigForPollingForUpdates) {
+      return this.edgeConfigIsHydrated;
     }
     return false;
   }


### PR DESCRIPTION
# Context
Currently, this DataAdapter requires you to call `EdgeConfigDataAdapter.initialize()` if it is to poll for new config updates from Vercel Edge Config rather than Statsig CDN. All this function is doing is checking if the Edge Config is hydrated.

This is undesirable in latency-sensitive workloads, because it requires an additional network call to configure the DataAdapter.

This PR makes it so that the DataAdapter will record after the first attempt to call the Vercel Edge Config whether or not it is hydrated.

If this is true and `useEdgeConfigForPollingForUpdates` is set to `true`, then Vercel Edge Config will be used for subsequent network requests made by the Statsig SDK.

# Summary

- Adds option to enable polling for Statsig config updates from Vercel Edge Config: `useEdgeConfigForPollingForUpdates` (true by default)
- Removes need for calling `EdgeConfigDataAdapter.initialize()` to use Vercel Edge Config for polling.