### PR TITLE
[fix] fix DataStore key pattern match, bump version to 0.8.1

### DIFF
--- a/EdgeConfigDataAdapter.ts
+++ b/EdgeConfigDataAdapter.ts
@@ -91,6 +91,11 @@ export class EdgeConfigDataAdapter implements IDataAdapter {
   private isConfgSpecKey(key: string): boolean {
     const v2CacheKeyPattern =
       /^statsig\|\/v[12]\/download_config_specs\|.+\|.+/;
-    return key === "statsig.cache" || v2CacheKeyPattern.test(key);
+    return (
+      key === "statsig.cache" ||
+      key === '/v1/download_config_specs' ||
+      key === '/v2/download_config_specs' ||
+      v2CacheKeyPattern.test(key)
+    );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "statsig-node-vercel",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "statsig-node-vercel",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "ISC",
       "dependencies": {
         "statsig-node-lite": "^0.4.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsig-node-vercel",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
- fixed: the regex pattern match was checking for a key format that isn't used by the Node.js SDK
- moved the expensive regex pattern match to the end of the conditional